### PR TITLE
Fix links

### DIFF
--- a/README copy 2.md
+++ b/README copy 2.md
@@ -221,7 +221,7 @@ And once that's done, you'll next want to head to your config.plist and disable 
 
 ### AMD and 3rd Party USB Mapping
 
-To be written, for now see the  [AMD-USB-map.md](https://github.com/dortania/USB-Map-Guide/blob/master/AMD/AMD-USB-map.md) for the time being.
+To be written, for now see the  [AMD-USB-map.md](/amd-mapping/amd.md) for the time being.
 
 For all I care, AMD hackintoshes don't exist. Please don't make me look at another AMD DSDT please, just buy Intel
 
@@ -253,7 +253,7 @@ With Skylake and newer SMBIOS, Apple no longer provides USB power settings via, 
 * MacBookAir8,x  and newer
 * MacBookPro13,x and newer
 
-Luckily you can use a precompiled file for USBX: [SSDT-USBX](https://github.com/khronokernel/USB-Map-Guide/blob/master/extra-files/SSDT-USBX.aml)
+Luckily you can use a precompiled file for USBX: [SSDT-USBX](/extra-files/SSDT-USBX.aml)
 
 ## Fixing Shutdown/Restart
 
@@ -261,8 +261,8 @@ So an odd quirk you may run into with macOS is that when you shutdown, your PC m
 
 For this we need the following:
 
-* [FixShutdown-USB-SSDT.dsl](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/FixShutdown-USB-SSDT.dsl)
-* [_PTS to ZPTS Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/FixShutdown-Patch.plist)
+* [FixShutdown-USB-SSDT.dsl](/extra-files/FixShutdown-USB-SSDT.dsl)
+* [_PTS to ZPTS Patch](/extra-files/FixShutdown-Patch.plist)
 * USB Controller's ACPI Path
 
 To find the USB Controller that needs fixing, search for `_PRW` in your DSDT and see what Device is mentioned within it, generally this will be something like `SB.PCI0.XHC`.
@@ -277,9 +277,9 @@ Similar idea to the "Fixing Shutdown/Restart" section, macOS will instant wake i
 
 | SSDT | ACPI Patch | Comments |
 | :--- | :--- | :--- |
-| [SSDT-GPRW](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-GPRW.aml) | [GPRW to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/GPRW-Patch.plist) | Use this if you have `Method (GPRW, 2` in your ACPI |
-| [SSDT-UPRW](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-UPRW) | [UPRW to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/UPRW-Patch.plist) | Use this if you have `Method (UPRW, 2` in your ACPI |
-| [SSDT-LANC](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-LANC.aml) | [LANC to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/LANC-Patch.plist) | Use this if you have  `Device (LANC)` in your ACPI |
+| [SSDT-GPRW](/extra-files/SSDT-GPRW.aml) | [GPRW to XPRW Patch](/extra-files/GPRW-Patch.plist) | Use this if you have `Method (GPRW, 2` in your ACPI |
+| [SSDT-UPRW](/extra-files/SSDT-UPRW) | [UPRW to XPRW Patch](/extra-files/UPRW-Patch.plist) | Use this if you have `Method (UPRW, 2` in your ACPI |
+| [SSDT-LANC](/extra-files/SSDT-LANC.aml) | [LANC to XPRW Patch](/extra-files/LANC-Patch.plist) | Use this if you have  `Device (LANC)` in your ACPI |
 
 ACPI Patches and SSDTs courtesy of [Rehabman](https://www.tonymacx86.com/threads/guide-using-clover-to-hotpatch-acpi.200137/), 1Revenger1 and Fewtarius
 

--- a/README copy 2.md
+++ b/README copy 2.md
@@ -221,7 +221,7 @@ And once that's done, you'll next want to head to your config.plist and disable 
 
 ### AMD and 3rd Party USB Mapping
 
-To be written, for now see the  [AMD-USB-map.md](/amd-mapping/amd.md) for the time being.
+To be written, for now see the  [AMD-USB-map.md](/amd-mapping/AMD-USB-map.md) for the time being.
 
 For all I care, AMD hackintoshes don't exist. Please don't make me look at another AMD DSDT please, just buy Intel
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,7 +10,7 @@
 
 ## AMD/3rd Party Mapping
 
-* [AMD and 3rd Party USB Mapping](/amd-mapping/amd.md)
+* [AMD and 3rd Party USB Mapping](/amd-mapping/AMD-USB-map.md)
 
 ## Miscellaneous Fixes
 

--- a/amd-mapping/amd.md
+++ b/amd-mapping/amd.md
@@ -74,7 +74,7 @@ All of our ports are here! So why in the world is macOS hiding them? Well there'
 
 Inside the `AppleUSBHostPlatformProperties.kext` you'll find the USB map for most SMBIOS, this means that that machine's USB map is forced onto your system. 
 
-Well to kick out these bad maps, we gotta make a plugin kext. For us, that's the [AMD-USB-Map.kext](https://github.com/dortania/USB-Map-Guide/tree/master/extra-files/AMD-USB-Map.kext.zip)
+Well to kick out these bad maps, we gotta make a plugin kext. For us, that's the [AMD-USB-Map.kext](/extra-files/AMD-USB-Map.kext.zip)
 
 Now right-click and press `Show Package Contents`, then navigate to `Contents/Info.plist`
 
@@ -143,7 +143,7 @@ With the SSDT Recreation method, what we'll be doing is "renaming" the device bu
 
 To do this, grab the following SSDT:
 
-* [SSDT-SHC0.dsl](https://github.com/dortania/USB-Map-Guide/tree/master/extra-files/SSDT-SHC0.dsl)
+* [SSDT-SHC0.dsl](/extra-files/SSDT-SHC0.dsl)
 
 What you'll want to do is find a controller you want to rename, find its full ACPI path and replace the one in the sample SSDT. In our sample, we're be renaming `PCI0.GP13.XHC0` to `SHC0` so change accordingly.
 

--- a/misc/instant-wake.md
+++ b/misc/instant-wake.md
@@ -6,8 +6,8 @@ Similar idea to the "Fixing Shutdown/Restart" section, macOS will instant wake i
 
 | SSDT | ACPI Patch | Comments |
 | :--- | :--- | :--- |
-| [SSDT-GPRW](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-GPRW.aml) | [GPRW to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/GPRW-Patch.plist) | Use this if you have `Method (GPRW, 2` in your ACPI |
-| [SSDT-UPRW](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-UPRW) | [UPRW to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/UPRW-Patch.plist) | Use this if you have `Method (UPRW, 2` in your ACPI |
-| [SSDT-LANC](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-LANC.aml) | [LANC to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/LANC-Patch.plist) | Use this if you have  `Device (LANC)` in your ACPI |
+| [SSDT-GPRW](/extra-files/SSDT-GPRW.aml) | [GPRW to XPRW Patch](/extra-files/GPRW-Patch.plist) | Use this if you have `Method (GPRW, 2` in your ACPI |
+| [SSDT-UPRW](/extra-files/SSDT-UPRW) | [UPRW to XPRW Patch](/extra-files/UPRW-Patch.plist) | Use this if you have `Method (UPRW, 2` in your ACPI |
+| [SSDT-LANC](/extra-files/SSDT-LANC.aml) | [LANC to XPRW Patch](/extra-files/LANC-Patch.plist) | Use this if you have  `Device (LANC)` in your ACPI |
 
 ACPI Patches and SSDTs courtesy of [Rehabman](https://www.tonymacx86.com/threads/guide-using-clover-to-hotpatch-acpi.200137/), 1Revenger1 and Fewtarius

--- a/misc/power.md
+++ b/misc/power.md
@@ -9,4 +9,4 @@ With Skylake and newer SMBIOS, Apple no longer provides USB power settings via I
 * MacBookAir8,x  and newer
 * MacBookPro13,x and newer
 
-Luckily you can use a precompiled file for USBX: [SSDT-USBX](https://github.com/khronokernel/USB-Map-Guide/blob/master/extra-files/SSDT-USBX.aml)
+Luckily you can use a precompiled file for USBX: [SSDT-USBX](/extra-files/SSDT-USBX.aml)

--- a/misc/shutdown.md
+++ b/misc/shutdown.md
@@ -4,8 +4,8 @@ So an odd quirk you may run into with macOS is that when you shutdown, your PC m
 
 For this we need the following:
 
-* [FixShutdown-USB-SSDT.dsl](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/FixShutdown-USB-SSDT.dsl)
-* [_PTS to ZPTS Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/FixShutdown-Patch.plist)
+* [FixShutdown-USB-SSDT.dsl](/extra-files/FixShutdown-USB-SSDT.dsl)
+* [_PTS to ZPTS Patch](/extra-files/FixShutdown-Patch.plist)
 * USB Controller's ACPI Path
 
 To find the USB Controller that needs fixing, search for `_PRW` in your DSDT and see what Device is mentioned within it, generally this will be something like `SB.PCI0.XHC`.

--- a/post-install/usb.md
+++ b/post-install/usb.md
@@ -221,7 +221,7 @@ And once that's done, you'll next want to head to your config.plist and disable 
 
 ### AMD and 3rd Party USB Mapping
 
-To be written, for now see the  [AMD-USB-map.md](https://github.com/dortania/USB-Map-Guide/blob/master/AMD/AMD-USB-map.md) for the time being.
+To be written, for now see the  [AMD-USB-map.md](/amd-mapping/amd.md) for the time being.
 
 For all I care, AMD hackintoshes don't exist. Please don't make me look at another AMD DSDT please, just buy Intel
 
@@ -253,7 +253,7 @@ With Skylake and newer SMBIOS, Apple no longer provides USB power settings via, 
 * MacBookAir8,x  and newer
 * MacBookPro13,x and newer
 
-Luckily you can use a precompiled file for USBX: [SSDT-USBX](https://github.com/khronokernel/USB-Map-Guide/blob/master/extra-files/SSDT-USBX.aml)
+Luckily you can use a precompiled file for USBX: [SSDT-USBX](/extra-files/SSDT-USBX.aml)
 
 ## Fixing Shutdown/Restart
 
@@ -261,8 +261,8 @@ So an odd quirk you may run into with macOS is that when you shutdown, your PC m
 
 For this we need the following:
 
-* [FixShutdown-USB-SSDT.dsl](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/FixShutdown-USB-SSDT.dsl)
-* [_PTS to ZPTS Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/FixShutdown-Patch.plist)
+* [FixShutdown-USB-SSDT.dsl](/extra-files/FixShutdown-USB-SSDT.dsl)
+* [_PTS to ZPTS Patch](/extra-files/FixShutdown-Patch.plist)
 * USB Controller's ACPI Path
 
 To find the USB Controller that needs fixing, search for `_PRW` in your DSDT and see what Device is mentioned within it, generally this will be something like `SB.PCI0.XHC`.
@@ -277,9 +277,9 @@ Similar idea to the "Fixing Shutdown/Restart" section, macOS will instant wake i
 
 | SSDT | ACPI Patch | Comments |
 | :--- | :--- | :--- |
-| [SSDT-GPRW](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-GPRW.aml) | [GPRW to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/GPRW-Patch.plist) | Use this if you have `Method (GPRW, 2` in your ACPI |
-| [SSDT-UPRW](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-UPRW) | [UPRW to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/UPRW-Patch.plist) | Use this if you have `Method (UPRW, 2` in your ACPI |
-| [SSDT-LANC](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/SSDT-LANC.aml) | [LANC to XPRW Patch](https://github.com/dortania/USB-Map-Guide/blob/master/extra-files/LANC-Patch.plist) | Use this if you have  `Device (LANC)` in your ACPI |
+| [SSDT-GPRW](/extra-files/SSDT-GPRW.aml) | [GPRW to XPRW Patch](/extra-files/GPRW-Patch.plist) | Use this if you have `Method (GPRW, 2` in your ACPI |
+| [SSDT-UPRW](/extra-files/SSDT-UPRW) | [UPRW to XPRW Patch](/extra-files/UPRW-Patch.plist) | Use this if you have `Method (UPRW, 2` in your ACPI |
+| [SSDT-LANC](/extra-files/SSDT-LANC.aml) | [LANC to XPRW Patch](/extra-files/LANC-Patch.plist) | Use this if you have  `Device (LANC)` in your ACPI |
 
 ACPI Patches and SSDTs courtesy of [Rehabman](https://www.tonymacx86.com/threads/guide-using-clover-to-hotpatch-acpi.200137/), 1Revenger1 and Fewtarius
 

--- a/post-install/usb.md
+++ b/post-install/usb.md
@@ -221,7 +221,7 @@ And once that's done, you'll next want to head to your config.plist and disable 
 
 ### AMD and 3rd Party USB Mapping
 
-To be written, for now see the  [AMD-USB-map.md](/amd-mapping/amd.md) for the time being.
+To be written, for now see the  [AMD-USB-map.md](/amd-mapping/AMD-USB-map.md) for the time being.
 
 For all I care, AMD hackintoshes don't exist. Please don't make me look at another AMD DSDT please, just buy Intel
 

--- a/system-preparation.md
+++ b/system-preparation.md
@@ -71,4 +71,4 @@ And for those worried about ACPI patches applying to other OSes, these will only
 But now we must part into 2 sections, depending on which hardware you have:
 
 * [Intel USB Mapping](/intel-mapping/intel.md)
-* [AMD and 3rd Party USB Mapping](/amd-mapping/amd.md)
+* [AMD and 3rd Party USB Mapping](/amd-mapping/AMD-USB-map.md)


### PR DESCRIPTION
Actually stumbled upon the link to the SSDT-USBX.aml file which directed to old home of the guide(s) at https://github.com/khronokernel. This was obviously "[not the web page Ⅰ was looking for](https://github.com/404)".

Ⅰ then decided to fix all the broken and local links. :-)